### PR TITLE
Add Family Guy Clips as overstimulation method

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,11 @@ const videoSources: Array<VideoSource> = [
         videos: ["intRX7BRA90", "n_Dv4JMiwK8", "GTaXbH6iSFA", "t3SpmH9QQew"],
         width: 600,
     },
+    {
+        label: "Family Guy Clips",
+        videos: ["y5a0ljo-ocI", "Zxl28UgHpn0", "mn-Tlb_wfjc", "fytR78K6rHs"],
+        width: 600,
+    }
 ];
 
 // This method is called when your extension is activated


### PR DESCRIPTION
Adds `Family Guy Clips` as an overstimulation method.
Includes links to a 37-min video, 33-min video, 43-min video and 1-hour video.


https://user-images.githubusercontent.com/16616914/235811452-e1db1a95-e62b-4351-b9ef-8583f995daef.mov

