### PR TITLE
User defined sources

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,43 @@
         "command": "subway-surfers.overstimulate",
         "title": "This code boring ah hell 💀"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Subway Surfers",
+      "properties": {
+        "subway-surfers.customSources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "description": "Custom sources",
+            "required": [
+              "label",
+              "videos",
+              "width"
+            ],
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "Name of the video source"
+              },
+              "videos": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "List of Youtube ID's",
+                "default": []
+              },
+              "width": {
+                "type": "number",
+                "description": "The width you want the video to be in pixels",
+                "default": 300
+              }
+            }
+          }
+        }
+      }
+    }
   },
   "pricing": "Free",
   "scripts": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,11 +4,11 @@ import * as vscode from "vscode";
 
 type VideoSource = {
     label: string;
-    videos: Array<string>;
+    videos: string[];
     width: number;
 };
 
-const videoSources: Array<VideoSource> = [
+const internalVideoSources: VideoSource[] = [
     {
         label: "Subway Surfers",
         videos: ["nNGQ7kMhGuQ", "Tqne5J7XdPA", "hs7Z0JUgDeA", "iYgYfHb8gbQ"],
@@ -34,6 +34,8 @@ const videoSources: Array<VideoSource> = [
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
 export function activate(context: vscode.ExtensionContext) {
+    const userVideoSources: VideoSource[] = vscode.workspace.getConfiguration().get('subway-surfers.customSources') || [];
+    const videoSources = internalVideoSources.concat(userVideoSources);
     // The command has been defined in the package.json file
     // Now provide the implementation of the command with registerCommand
     // The commandId parameter must match the command field in package.json


### PR DESCRIPTION
Ability for users to add custom sources and URL's locally.

Example:
```json
"subway.surfers.customSources": [
  {
    "label": "Soap videos",
    "videos": [
      "a2vzWDqJRKg",
      "GdALx9LS_uY",
      "BZ6xsmyQsZQ"
    ],
    "width": 300
  },
]
  ```